### PR TITLE
feat: admin panel

### DIFF
--- a/admin/navigation.json
+++ b/admin/navigation.json
@@ -1,0 +1,5 @@
+{
+  "section": "marketplace",
+  "titleId": "admin/cross-device-cart.title",
+  "path": "/admin/cross-device-cart"
+}

--- a/admin/routes.json
+++ b/admin/routes.json
@@ -1,0 +1,6 @@
+{
+  "admin.app.cross-device-cart": {
+    "component": "AdminPanel",
+    "path": "/admin/app/cross-device-cart"
+  }
+}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -4,6 +4,11 @@ type Query {
   """
   getSavedCart(userId: String!, isAutomatic: Boolean): String
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
+
+  """
+  Retrieve app settings
+  """
+  getAppSettings: CrossDeviceCartSettings
 }
 
 type Mutation {
@@ -20,4 +25,9 @@ type Mutation {
     strategy: Strategy
     userId: String!
   ): OrderForm
+
+  """
+  Save app settings
+  """
+  saveAppSettings(isAutomatic: Boolean): Boolean
 }

--- a/graphql/types/global.graphql
+++ b/graphql/types/global.graphql
@@ -6,6 +6,10 @@ enum Strategy {
 
 scalar InputValues
 
+type CrossDeviceCartSettings {
+  isAutomatic: Boolean
+}
+
 """
  We don't actually care what subfields are returned as this is used mainly
 by the setOrderForm callback; used to update the storefront context

--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,7 @@
   "title": "Cross device cart",
   "description": "Seamlessly allow a client to retrieve items left on a different device's cart",
   "builders": {
+    "admin": "0.x",
     "react": "3.x",
     "docs": "0.x",
     "store": "0.x",
@@ -22,9 +23,7 @@
     "vtex.order-manager": "0.x",
     "vtex.pixel-manager": "1.x"
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "credentialType": "absolute",
   "policies": [
     {
@@ -60,9 +59,7 @@
       "url": "https://support.vtex.com/hc/requests"
     },
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -9,5 +9,12 @@
   "store/crossCart.modal.buttons.title": "Merge options title",
   "store/crossCart.modal.buttons.merge": "Merge carts option",
   "store/crossCart.modal.buttons.replace": "Replace cart option",
-  "store/crossCart.modal.buttons.add": "Add carts option"
+  "store/crossCart.modal.buttons.add": "Add carts option",
+  "admin/cross-device-cart.title": "Admin panel title",
+  "admin/cross-device-cart.subtitle": "Admin panel subtitle",
+  "admin/cross-device-cart.error": "Alert on error fetching the app settings",
+  "admin/cross-device-cart.automatic-toggle-automatic": "Automatic toggle label when toggle is on",
+  "admin/cross-device-cart.automatic-toggle-manual": "Automatic toggle label when toggle is off",
+  "admin/cross-device-cart.automatic-toggle-help-text": "Automatic toggle help text",
+  "admin/cross-device-cart.automatic-toggle-explanation": "Automatic toggle modes explanation"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -9,5 +9,12 @@
   "store/crossCart.modal.buttons.title": "What would you like to do with your previous cart?",
   "store/crossCart.modal.buttons.merge": "Merge carts",
   "store/crossCart.modal.buttons.replace": "Replace",
-  "store/crossCart.modal.buttons.add": "Add carts"
+  "store/crossCart.modal.buttons.add": "Add carts",
+  "admin/cross-device-cart.title": "Cross Device Cart",
+  "admin/cross-device-cart.subtitle": "App Settings",
+  "admin/cross-device-cart.error": "There was a problem loading the application settings",
+  "admin/cross-device-cart.automatic-toggle-automatic": "Automatic",
+  "admin/cross-device-cart.automatic-toggle-manual": "Manual",
+  "admin/cross-device-cart.automatic-toggle-help-text": "Toggle between Automatic and Manual mode for the cross device cart.",
+  "admin/cross-device-cart.automatic-toggle-explanation": "When the 'Automatic' mode is selected the user will not be prompted to take any action. If 'Manual' mode is selected the user will need to confirm what they want to do with the items that were previously in the cart."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -9,5 +9,12 @@
   "store/crossCart.modal.buttons.title": "¿Qué te gustaría hacer con tu carrito anterior?",
   "store/crossCart.modal.buttons.merge": "Combinar",
   "store/crossCart.modal.buttons.replace": "Reemplazar",
-  "store/crossCart.modal.buttons.add": "Sumar"
+  "store/crossCart.modal.buttons.add": "Sumar",
+  "admin/cross-device-cart.title": "Cross Device Cart",
+  "admin/cross-device-cart.subtitle": "Configuración de la aplicación",
+  "admin/cross-device-cart.error": "Ha ocurrido un problema cargando la configuración de la aplicación",
+  "admin/cross-device-cart.automatic-toggle-automatic": "Automático",
+  "admin/cross-device-cart.automatic-toggle-manual": "Manual",
+  "admin/cross-device-cart.automatic-toggle-help-text": "Elija entre el modo Automático o Manual para el cross device cart.",
+  "admin/cross-device-cart.automatic-toggle-explanation": "Cuando se selecciona el modo 'Automático' no se le pedirá al usuario que realice ninguna acción. Si se selecciona el modo 'Manual' el usuario deberá confirmar qué quiere hacer con los artículos que estaban previamente en el carrito."
 }

--- a/node/constants/index.ts
+++ b/node/constants/index.ts
@@ -1,1 +1,3 @@
 export const APP_NAME = 'vtex.cross-device-cart'
+export const BUCKET = 'cross_device_cart'
+export const SETTINGS_PATH = 'app_settings'

--- a/node/resolvers/getAppSettings.ts
+++ b/node/resolvers/getAppSettings.ts
@@ -1,0 +1,24 @@
+import { BUCKET, SETTINGS_PATH } from '../constants'
+
+export const getAppSettings = async (
+  _: unknown,
+  __: unknown,
+  { clients: { vbase }, vtex: { logger } }: Context
+): Promise<AppSettings | null> => {
+  try {
+    const appSettings: AppSettings = await vbase.getJSON(
+      BUCKET,
+      SETTINGS_PATH,
+      true
+    )
+
+    return appSettings
+  } catch (error) {
+    logger.error({
+      message: 'There was a problem fetching the app settings',
+      error,
+    })
+
+    return null
+  }
+}

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -1,12 +1,16 @@
+import { getAppSettings } from './getAppSettings'
 import { getSavedCart } from './getSavedCart'
+import { saveAppSettings } from './saveAppSettings'
 import { saveCurrentCart } from './saveCurrentCart'
 import { mergeCarts } from './mergeCarts'
 
 export const queries = {
+  getAppSettings,
   getSavedCart,
 }
 
 export const mutations = {
+  saveAppSettings,
   saveCurrentCart,
   mergeCarts,
 }

--- a/node/resolvers/saveAppSettings.ts
+++ b/node/resolvers/saveAppSettings.ts
@@ -1,0 +1,24 @@
+import { BUCKET, SETTINGS_PATH } from '../constants'
+
+export const saveAppSettings = async (
+  _: unknown,
+  { isAutomatic }: AppSettings,
+  { clients: { vbase }, vtex: { logger } }: Context
+): Promise<boolean> => {
+  const settings = {
+    isAutomatic,
+  }
+
+  try {
+    await vbase.saveJSON(BUCKET, SETTINGS_PATH, settings)
+
+    return true
+  } catch (error) {
+    logger.error({
+      message: 'There was a problem saving the app settings',
+      error,
+    })
+
+    return false
+  }
+}

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -4,11 +4,11 @@ type AssemblyOptionType = import('vtex.checkout-graphql').AssemblyOptionType
 interface MergeCartsVariables {
   savedCart: Scalars['ID']
   currentCart: Scalars['ID']
-  strategy: MergeStrategy
+  strategy: Strategy
   userId: Scalars['ID']
 }
 
-type MergeStrategy = 'ADD' | 'COMBINE' | 'REPLACE'
+type Strategy = 'ADD' | 'COMBINE' | 'REPLACE'
 
 interface PartialOrderFormItems {
   orderForm: { items: PartialItem[] }
@@ -63,4 +63,8 @@ interface CrossCartData {
 
 interface SaveCurrentCartData extends CrossCartData {
   userId: string
+}
+
+interface AppSettings {
+  isAutomatic: boolean
 }

--- a/react/AdminPanel.tsx
+++ b/react/AdminPanel.tsx
@@ -1,0 +1,3 @@
+import { AdminPanel } from './components/admin/AdminPanel'
+
+export default AdminPanel

--- a/react/components/admin/AdminPanel.tsx
+++ b/react/components/admin/AdminPanel.tsx
@@ -1,0 +1,93 @@
+import React, { FC, Fragment, useEffect, useState } from 'react'
+import { FormattedMessage } from 'react-intl'
+import {
+  Alert,
+  Layout,
+  PageBlock,
+  PageHeader,
+  Spinner,
+  Toggle,
+  Divider,
+} from 'vtex.styleguide'
+import { useMutation, useQuery } from 'react-apollo'
+
+import GET_APP_SETTINGS from '../../graphql/getAppSettings.gql'
+import SAVE_APP_SETTINGS from '../../graphql/saveAppSettings.gql'
+
+const AdminPanel: FC = () => {
+  const [isAutomatic, setIsAutomatic] = useState(true)
+  const { data, loading: loadingSettings, error: settingsError } = useQuery(
+    GET_APP_SETTINGS
+  )
+
+  const [saveSettings] = useMutation(SAVE_APP_SETTINGS)
+
+  const handleToggleAutomatic = () => {
+    saveSettings({
+      variables: {
+        isAutomatic: !isAutomatic,
+      },
+    })
+    setIsAutomatic(!isAutomatic)
+  }
+
+  useEffect(() => {
+    if (data?.appSettings) {
+      setIsAutomatic(data.appSettings.isAutomatic)
+    }
+  }, [data?.appSettings])
+
+  if (settingsError) {
+    console.error(settingsError)
+  }
+
+  return (
+    <Layout
+      pageHeader={
+        <PageHeader
+          title={<FormattedMessage id="admin/cross-device-cart.title" />}
+          subtitle={<FormattedMessage id="admin/cross-device-cart.subtitle" />}
+        />
+      }
+    >
+      <PageBlock>
+        {settingsError ? (
+          <Alert type="error">
+            <FormattedMessage id="admin/cross-device-cart.error" />
+          </Alert>
+        ) : loadingSettings ? (
+          <div className="flex justify-center mv5">
+            <Spinner />
+          </div>
+        ) : (
+          <Fragment>
+            <Toggle
+              label={
+                isAutomatic ? (
+                  <FormattedMessage id="admin/cross-device-cart.automatic-toggle-automatic" />
+                ) : (
+                  <FormattedMessage id="admin/cross-device-cart.automatic-toggle-manual" />
+                )
+              }
+              semantic
+              checked={isAutomatic}
+              onChange={handleToggleAutomatic}
+              helpText={
+                <FormattedMessage id="admin/cross-device-cart.automatic-toggle-help-text" />
+              }
+            />
+
+            <div className="pt6">
+              <Divider />
+            </div>
+            <p className="gray lh-copy">
+              <FormattedMessage id="admin/cross-device-cart.automatic-toggle-explanation" />
+            </p>
+          </Fragment>
+        )}
+      </PageBlock>
+    </Layout>
+  )
+}
+
+export { AdminPanel }

--- a/react/graphql/getAppSettings.gql
+++ b/react/graphql/getAppSettings.gql
@@ -1,0 +1,5 @@
+query getAppSettings {
+  appSettings: getAppSettings {
+    isAutomatic
+  }
+}

--- a/react/graphql/saveAppSettings.gql
+++ b/react/graphql/saveAppSettings.gql
@@ -1,0 +1,3 @@
+mutation saveAppSettings($isAutomatic: Boolean) {
+  saveAppSettings(isAutomatic: $isAutomatic)
+}

--- a/react/typings/admin.d.ts
+++ b/react/typings/admin.d.ts
@@ -1,0 +1,3 @@
+interface Settings {
+  isAutomatic: boolean
+}


### PR DESCRIPTION
#### What this PR changes
This PR adds an Admin Panel to manage the app settings instead of declaring props on the store-theme.

#### How to test it
The app's Admin Panel can be found [here](https://xcartadmin--powerplanet.myvtex.com/admin/cross-device-cart).