### PR TITLE
fix: insert rootpath on orderform request

### DIFF
--- a/react/components/CrossCart.tsx
+++ b/react/components/CrossCart.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useEffect, useState } from 'react'
 import { useLazyQuery, useMutation } from 'react-apollo'
 import { useIntl } from 'react-intl'
+import { useRuntime } from 'vtex.render-runtime'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
 import axios from 'axios'
 
@@ -8,6 +9,7 @@ import GET_ID_BY_USER from '../graphql/getSavedCart.gql'
 import SAVE_ID_BY_USER from '../graphql/saveCurrentCart.gql'
 import MUTATE_CART from '../graphql/replaceCart.gql'
 import ChallengeBlock from './ChallengeBlock'
+import insertRootPath from '../utils/insertRootPath'
 
 interface Props {
   userId: string
@@ -18,6 +20,8 @@ interface Props {
 
 const CrossCart: FC<Props> = ({ userId, isAutomatic, strategy, showToast }) => {
   const { orderForm, setOrderForm } = useOrderForm() as OrderFormContext
+  const { rootPath = '' } = useRuntime()
+
   const [hasMerged, setMergeStatus] = useState(false)
   const [challengeActive, setChallenge] = useState(false)
   const intl = useIntl()
@@ -83,8 +87,13 @@ const CrossCart: FC<Props> = ({ userId, isAutomatic, strategy, showToast }) => {
     }
 
     try {
+      const orderFormURLWithRootPath = insertRootPath(
+        rootPath,
+        `/api/checkout/pub/orderForm/${data.id}`
+      )
+
       await axios.post(
-        `/api/checkout/pub/orderForm/${data.id}`,
+        orderFormURLWithRootPath,
         {},
         {
           headers: {

--- a/react/utils/insertRootPath.ts
+++ b/react/utils/insertRootPath.ts
@@ -1,0 +1,8 @@
+export default function insertRootPath(
+  rootPath: string | undefined,
+  apiRoute: string
+) {
+  const pathWithRootPath = rootPath ? `${rootPath}${apiRoute}` : apiRoute
+
+  return pathWithRootPath
+}


### PR DESCRIPTION
## What this PR changes
This PR inserts a rootpath in a orderform request, to handle specific cases where this path is needed.

## How to test
It should work on any website that uses rootpaths ([Angeloni](https://www.angeloni.com.br/super/?active_site=VTEX&workspace=sa783), for example)